### PR TITLE
Deactivating react-in-jsx-scope

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
     "react/prop-types": "off",
     "react/jsx-filename-extension": "off",
     "react/jsx-props-no-spreading": "off",
+    "react/react-in-jsx-scope": "off",
     "import/extensions": [
       "error",
       "ignorePackages",


### PR DESCRIPTION
As Next.js automatically imports `React` for you, it is not necessary to include every time. In order to prevent Husky from "Barking" over it being an error, passing `"react/react-in-jsx-scope": "off"` would be ideal.

![Screenshot 2020-11-28 at 17 43 20](https://user-images.githubusercontent.com/52371939/100522310-90934b80-31a1-11eb-92be-ebe714b92e31.png)
