### PR TITLE
Change TS Target to ES2015 and Enable Strict Mode

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,6 @@
 import '@/styles/global.css';
+import { AppProps } from 'next/app';
 
-export default function MyApp({ Component, pageProps }) {
+export default function MyApp({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;
 }

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,5 +1,5 @@
-import '@/styles/global.css';
 import { AppProps } from 'next/app';
+import '@/styles/global.css';
 
 export default function MyApp({ Component, pageProps }: AppProps) {
   return <Component {...pageProps} />;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "compilerOptions": {
-    "target": "es5",
+    "target": "es2015",
     "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
-    "strict": false,
+    "strict": true,
     "forceConsistentCasingInFileNames": true,
     "noEmit": true,
     "esModuleInterop": true,


### PR DESCRIPTION
Hello, 

Thanks again for this amazing template. 

One thing I consistently do after starting a new project is make this two changes for the following reason and was wondering if you'd consider adding them to the template. 

## Rationale 

1. nextjs itself only supports modern browser with es6+ support and IE11 with polyfills. We can safely use es2015 as target as compilation is done by nextjs/babel. This allows us to use advanced ecmascript features like **using spread operator to convert an Iterator to an Array without error or extra compiler flags.**

2. enabling strict mode helps us write better and safer code and it's recommended in most cases.

Let me know if any further changes needs to be done for this to be merged. 

## Changes Made

1. changed target to es2015 (es6)
2. changed strict mode to true
3. added type to src/pages/_app.tsx to pass strict mode (noImplicitAny)

## Test Plan

- [x] pass type check `yarn type-check`
- [x] start dev server `yarn dev`
- [x] prod build `yarn build`
