### PR TITLE
chore: run commitizen by using commit script

### DIFF
--- a/.husky/prepare-commit-msg
+++ b/.husky/prepare-commit-msg
@@ -1,5 +1,0 @@
-#!/bin/sh
-. "$(dirname "$0")/_/husky.sh"
-. "$(dirname "$0")/common.sh"
-
-exec < /dev/tty && yarn cz --hook || true

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "type-check": "tsc",
     "lint": "eslint --ignore-path .gitignore \"src/**/*.+(ts|js|tsx)\"",
     "format": "prettier --ignore-path .gitignore \"src/**/*.+(ts|js|tsx)\" --write",
-    "postinstall": "husky install"
+    "postinstall": "husky install",
+    "commit": "cz"
   },
   "lint-staged": {
     "./src/**/*.{ts,js,jsx,tsx}": [


### PR DESCRIPTION
This PR removes the husky script that runs commitizen on `git commit`.

Now it will be optional, and you can run it by using `yarn commit` or `npm run commit`.
