### PR TITLE
chore: disable renovating node version

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,5 +3,11 @@
   "semanticCommits": true,
   "stabilityDays": 3,
   "prCreation": "not-pending",
-  "labels": ["type: dependencies"]
+  "labels": ["type: dependencies"],
+  "packageRules": [
+    {
+      "packageNames": ["node"],
+      "enabled": false
+    }
+  ]
 }


### PR DESCRIPTION
Blocks this type of PR from being open https://github.com/jpedroschmitz/typescript-nextjs-starter/pull/287