### PR TITLE
removing @next/font at dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     ]
   },
   "dependencies": {
-    "@next/font": "13.2.4",
     "next": "13.2.4",
     "react": "18.2.0",
     "react-dom": "18.2.0"


### PR DESCRIPTION
At default next/font was added to Nextjs dependencies currently.