### PR TITLE
fix(ci): add permissions for commitlint github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,10 @@ jobs:
 
     name: Run Type Check & Linters
     runs-on: ubuntu-latest
-
+    permissions:
+      contents: read
+      pull-requests: read
+      
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
See: https://github.com/wagoid/commitlint-github-action

Find out more about permissions here: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/controlling-permissions-for-github_token

The workflow does not work without this. I believe they are doing something strange and rolling it out with backwards compatibility or something, which is why your workflow is not broken.